### PR TITLE
Some existing apps expect this to be present. 

### DIFF
--- a/jsonfield/__init__.py
+++ b/jsonfield/__init__.py
@@ -1,0 +1,1 @@
+from fields import JSONField


### PR DESCRIPTION
For example Gargoyle does this "from jsonfield import JSONField", expecting this (older) version of django-jsonfield to be present:

https://bitbucket.org/schinckel/django-jsonfield

If you could merge this in that would be brilliant :)
