### PR TITLE
Fix for Django 1.3

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -23,7 +23,7 @@ class JSONField(models.TextField):
 
         return value
 
-    def get_db_prep_save(self, value):
+    def get_db_prep_save(self, value, connection=None):
         """Convert our JSON object to a string before we save"""
 
         if not value or value == "":
@@ -32,7 +32,7 @@ class JSONField(models.TextField):
         if isinstance(value, (dict, list)):
             value = json.dumps(value, cls=DjangoJSONEncoder)
 
-        return super(JSONField, self).get_db_prep_save(value)
+        return super(JSONField, self).get_db_prep_save(value, connection)
 
 try:
     from south.modelsinspector import add_introspection_rules


### PR DESCRIPTION
Fix for Django 1.3 "DeprecationWarning: A Field class whose get_db_prep_save method hasn't been updated to take a `connection` argument."
