### PR TITLE
Fixed get_db_prep_save() error

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -32,7 +32,7 @@ class JSONField(models.TextField):
         if isinstance(value, (dict, list)):
             value = json.dumps(value, cls=DjangoJSONEncoder)
 
-        return super(JSONField, self).get_db_prep_save(value, connection)
+        return super(JSONField, self).get_db_prep_save(value, connection=connection)
 
 try:
     from south.modelsinspector import add_introspection_rules


### PR DESCRIPTION
When saving an object from the admin panel (Django 1.3) got a TypeError:
`get_db_prep_save() got multiple values for keyword argument 'connection'`
Fixed by adding a keyword argument.
