### PR TITLE
fix for django dumpdata command

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -50,7 +50,7 @@ class JSONField(models.TextField):
 
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
-        return self.get_db_prep_value(value)
+        return self.get_prep_value(value)
 
     def value_from_object(self, obj):
         return json.dumps(super(JSONField, self).value_from_object(obj))


### PR DESCRIPTION
Tried to do a dumpdata command in django and got the error: "Unable to serialize database: get_db_prep_value() takes at least 3 arguments (2 given)". This is a fix for that.
