### PR TITLE
Better targeted exception catching  

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -70,5 +70,5 @@ class JSONField(models.TextField):
 try:
     from south.modelsinspector import add_introspection_rules
     add_introspection_rules([], ["^jsonfield\.fields\.JSONField"])
-except:
+except ImportError:
     pass


### PR DESCRIPTION
It's bad practice to use `except` to catch all exceptions as it can mask other problems (e.g. if `add_introspection_rule` throws an error you'll never see it.)
