### PR TITLE
Django 1.5 compatibility

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -1,6 +1,6 @@
 from django.db import models
 from django.core.serializers.json import DjangoJSONEncoder
-from django.utils import simplejson as json
+import json
 from django.utils.translation import ugettext_lazy as _
 
 from django.forms.fields import Field


### PR DESCRIPTION
Django 1.5 deprecates django.utils.simplejson in favor of Python 2.6's built-in json module
