### PR TITLE
JSONField doesn't support django.core.seralizers, so fixtures don't work

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -60,7 +60,7 @@ class JSONFieldBase(models.Field):
 
     def value_to_string(self, obj):
         value = self._get_val_from_obj(obj)
-        return self.get_prep_value(value)
+        return self.get_db_prep_value(value, None)
 
     def value_from_object(self, obj):
         value = super(JSONFieldBase, self).value_from_object(obj)

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -114,15 +114,17 @@ class JSONFieldTest(TestCase):
 
     def test_django_serializers(self):
         for json_obj in [{}, [], 0, '', False, {'key': 'value', 'num': 42,
-                                                'ary': [range(5)],
+                                                'ary': range(5),
                                                 'dict': {'k': 'v'}}]:
             obj = self.json_model.objects.create(json=json_obj)
             new_obj = self.json_model.objects.get(id=obj.id)
 
         queryset = self.json_model.objects.all()
-        for dobj in deserialize('json', serialize('json', queryset)):
+        ser = serialize('json', queryset)
+        for dobj in deserialize('json', ser):
+            obj = dobj.object
             pulled = self.json_model.objects.get(id=obj.pk)
-            self.failUnlessEqual(dobj.json, pulled.json)
+            self.failUnlessEqual(obj.json, pulled.json)
 
 
 class JSONCharFieldTest(JSONFieldTest):


### PR DESCRIPTION
for now this is just a unit test demonstrating/tracking down the problem. i'm looking for a solution and haven't yet found one. 

the root problem is that the JSONField is written out with the python string representation of it's data rather than the django.core.seralizers serialized version (could be json, xml, yaml, ...)

not sure what will be required/if it'll be possible. going to start looking in to it now. 

thought i'd send a pull request in case it's an easy/quick fix for someone more familiar with the code.

btw, it was hard to figure out what was happening here since json errors are silently swallowed at fields.py:23. that seems like problematic error handling.

example of the output (note the python **repr** string for the "json" field)

[{"pk": 1, "model": "jsonfield.jsonmodel", "fields": {"json": "{}"}}, {"pk": 2, "model": "jsonfield.jsonmodel", "fields": {"json": "[]"}}, {"pk": 3, "model": "jsonfield.jsonmodel", "fields": {"json": 0}}, {"pk": 4, "model": "jsonfield.jsonmodel", "fields": {"json": ""}}, {"pk": 5, "model": "jsonfield.jsonmodel", "fields": {"json": false}}, {"pk": 6, "model": "jsonfield.jsonmodel", "fields": {"json": "{u'ary': [[0, 1, 2, 3, 4]], u'num': 42, u'dict': {u'k': u'v'}, u'key': u'value'}"}}]

best,
-rm
