### PR TITLE
Value error

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -43,9 +43,9 @@ class JSONFieldBase(models.Field):
     def to_python(self, value):
         """Convert string value to JSON"""
         if isinstance(value, basestring):
-            # empty value -> None
+            # empty value -> itself
             if value == '':
-                return None
+                return value
             # otherwise try and convert and see how things go, value errors
             # will be propogated so that thigns fail early/obvious
             return json.loads(value, **self.load_kwargs)

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -1,4 +1,5 @@
 from django.core.serializers import deserialize, serialize
+from django.core.serializers.base import DeserializationError
 from django.db import models
 from django.test import TestCase
 from django.utils import simplejson as json
@@ -129,10 +130,12 @@ class JSONFieldTest(TestCase):
         # invalid json data {] in the json and default_json fields
         ser = '[{"pk": 1, "model": "jsonfield.jsoncharmodel", ' \
             '"fields": {"json": "{]", "default_json": "{]"}}]'
-        with self.assertRaises(ValueError) as cm:
+        with self.assertRaises(DeserializationError) as cm:
             dobj = deserialize('json', ser).next()
+        inner = cm.exception.args[0]
+        self.assertTrue(isinstance(inner, ValueError))
         self.assertEquals('Expecting property name: line 1 column 1 (char 1)',
-                          cm.exception.args[0])
+                          inner.args[0])
 
 
 class JSONCharFieldTest(JSONFieldTest):


### PR DESCRIPTION
looks like handling '' manually was all that was required to otherwise let json.load do it's thing. ValueErrors are now raised if the json's bad so data won't disappear without any notice.
