### PR TITLE
Raise ValidationError on ValueError

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -46,9 +46,10 @@ class JSONFieldBase(models.Field):
             # empty value -> itself
             if value == '':
                 return value
-            # otherwise try and convert and see how things go, value errors
-            # will be propogated so that things fail early/obvious
-            return json.loads(value, **self.load_kwargs)
+            try:
+                json.loads(value, **self.load_kwargs)
+            except ValueError:
+                raise FormValidationError(_("Enter valid JSON"))
         return value
 
     def get_db_prep_value(self, value, connection, prepared=False):


### PR DESCRIPTION
As discussed in [djangorestframework#628](https://github.com/tomchristie/django-rest-framework/issues/628#issuecomment-12798853):

> Converts the input value into the expected Python data type, raising django.core.exceptions.ValidationError if the data can't be converted. 
> Returns the converted value. Subclasses should override this.
