### PR TITLE
Add support for PostgreSQL 9.2+'s native json type.

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -107,6 +107,12 @@ class JSONFieldBase(models.Field):
         # If the field doesn't have a default, then we punt to models.Field.
         return super(JSONFieldBase, self).get_default()
 
+    def db_type(self, connection):
+        if connection.vendor == 'postgresql' and connection.pg_version >= 90200:
+            return 'json'
+        else:
+            return super(JSONFieldBase, self).db_type(connection)
+
 
 class JSONField(JSONFieldBase, models.TextField):
     """JSONField is a generic textfield that serializes/unserializes JSON objects"""


### PR DESCRIPTION
The patch keeps things portable by still returning 'text' for unsupported databases/versions.
