### PR TITLE
Added relative import of fields module

### DIFF
--- a/jsonfield/__init__.py
+++ b/jsonfield/__init__.py
@@ -1,1 +1,1 @@
-from fields import JSONField, JSONCharField
+from .fields import JSONField, JSONCharField

--- a/jsonfield/tests.py
+++ b/jsonfield/tests.py
@@ -5,7 +5,7 @@ from django.db import models
 from django.test import TestCase
 from django.utils import simplejson as json
 
-from fields import JSONField, JSONCharField
+from .fields import JSONField, JSONCharField
 from django.forms.util import ValidationError
 
 from collections import OrderedDict


### PR DESCRIPTION
I added relative importing for the field module.  I am using python3 and the code fails because py3 doesn't allow for relative importing without the . usage.  There are other changes needed for python3 based around str, but 2to3 takes care of those.
