### PR TITLE
fallback to six if present

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -2,7 +2,11 @@ import copy
 from django.db import models
 from django.core.serializers.json import DjangoJSONEncoder
 from django.utils.translation import ugettext_lazy as _
-from django.utils import six
+
+try:
+    from django.utils import six
+except ImportError:
+    import six
 
 try:
     import json


### PR DESCRIPTION
While using JSONfield with Django on Windows7, I installed Jsonfield with pip. And integrated it with my app, but when I used it one my models and tried to migrate it with south. It couldnt import django.utils.six. 

Then I installed six using pip and added that in the fields.py. 

And it worked well! I m including this screenshot of the traceback of the failed import
![traceback](https://f.cloud.github.com/assets/1097043/520198/2e7b42a4-bf30-11e2-928f-9bc05c9f26aa.png)
