### PR TITLE
Fix signature of six.with_metaclass.

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -47,7 +47,7 @@ class JSONCharFormField(JSONFormFieldBase, fields.CharField):
     pass
 
 
-class JSONFieldBase(six.with_metaclass(SubfieldBase, base=models.Field)):
+class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
 
     def __init__(self, *args, **kwargs):
         self.dump_kwargs = kwargs.pop('dump_kwargs', {


### PR DESCRIPTION
In six 1.4, the signature of `with_metaclass` has changed from `with_metaclass(meta, base=object)` to `with_metaclass(meta, *bases)`, allowing for multiple bases. This breaks django-jsonfield, which uses the `base` kwarg name explicitly. Since Django 1.6b3 updated the bundled `django.utils.six` to version 1.4.1, this also makes jsonfield broken with Django 1.6b3.

This pull request fixes django-jsonfield's use of `six.with_metaclass` to not specify the base as a kwarg, but rather as a positional arg, making it compatible with both older and newer versions of Django/six.
