### PR TITLE
Problem when iterating if default value is '""' on postgresql-9.3

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -72,7 +72,8 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
             if not hasattr(obj, "pk") or obj.pk is not None:
                 if isinstance(value, six.string_types):
                     try:
-                        return json.loads(value, **self.load_kwargs)
+                        return value if value == "" \
+                            else json.loads(value, **self.load_kwargs)
                     except ValueError:
                         raise ValidationError(_("Enter valid JSON"))
 


### PR DESCRIPTION
In [1]: from my_app.models import MyModel
## In [2]: [fo for fo in MyModel.objects.all()]

ValidationError                           Traceback (most recent call last)
<ipython-input-2-cfc56292ecdd> in <module>()
----> 1 [fo for fo in MyModel.objects.all()]

/home/florent/.virtualenvs/<somewhere>/local/lib/python2.7/site-packages/django/db/models/query.pyc in **iter**(self)
     94                - Responsible for turning the rows into model objects.
     95         """
---> 96         self._fetch_all()
     97         return iter(self._result_cache)
     98 

/home/florent/.virtualenvs/<somewhere>/local/lib/python2.7/site-packages/django/db/models/query.pyc in _fetch_all(self)
    852     def _fetch_all(self):
    853         if self._result_cache is None:
--> 854             self._result_cache = list(self.iterator())
    855         if self._prefetch_related_lookups and not self._prefetch_done:
    856             self._prefetch_related_objects()

/home/florent/.virtualenvs/<somewhere>/local/lib/python2.7/site-packages/django/db/models/query.pyc in iterator(self)
    228                     obj = model_cls(*_dict(zip(init_list, row_data)))
    229                 else:
--> 230                     obj = model(_row_data)
    231 
    232                 # Store the source database of the object

/home/florent/.virtualenvs/<somewhere>/local/lib/python2.7/site-packages/django/db/models/base.pyc in **init**(self, _args, *_kwargs)
    345             # without changing the logic.
    346             for val, field in zip(args, fields_iter):
--> 347                 setattr(self, field.attname, val)
    348         else:
    349             # Slower, kwargs-ready version.

/home/florent/Work/<somewhere>/django-jsonfield/jsonfield/subclassing.pyc in **set**(self, obj, value)
     39         # we can definitively tell if a value has already been deserialized
     40         # More: https://github.com/bradjasper/django-jsonfield/issues/33
---> 41         obj.**dict**[self.field.name] = self.field.pre_init(value, obj)
     42 
     43 

/home/florent/Work/<somewhere>/django-jsonfield/jsonfield/fields.pyc in pre_init(self, value, obj)
     75                         return json.loads(value, **self.load_kwargs)
     76                     except ValueError:
---> 77                         raise ValidationError(_("Enter valid JSON"))
     78 
     79         return value

ValidationError: [u'Enter valid JSON']
