### PR TITLE
attempt to import django.forms.utils rather than django.forms.util

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -13,7 +13,10 @@ except ImportError:
     from django.utils import simplejson as json
 
 from django.forms import fields
-from django.forms.util import ValidationError
+try:
+    from django.forms.utils import ValidationError
+except ImportError:
+    from django.forms.util import ValidationError
 
 from .subclassing import SubfieldBase
 


### PR DESCRIPTION
In django 1.7+, importing from django.forms.util has been deprecated in favor of using django.forms.utils.
