### PR TITLE
Change subclass of JSONFormField to CharField

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -43,7 +43,7 @@ class JSONFormFieldBase(object):
             raise ValidationError(_("Enter valid JSON"))
 
 
-class JSONFormField(JSONFormFieldBase, fields.Field):
+class JSONFormField(JSONFormFieldBase, fields.CharField):
     pass
 
 class JSONCharFormField(JSONFormFieldBase, fields.CharField):


### PR DESCRIPTION
This eliminates the problem where Django's model TextField passes parameters to the **init** of JSONFormField which it can't handle by using a CharField's **init**. This is untested beyond working on my install, I've added no tests.

This is in response to bradjasper/django-jsonfield#72
