### PR TITLE
attempt to import simplejson first for speed improvements

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -8,9 +8,12 @@ except ImportError:
     import six
 
 try:
-    import json
+    import simplejson as json
 except ImportError:
-    from django.utils import simplejson as json
+    try:
+        import json
+    except ImportError:
+        from django.utils import simplejson as json
 
 from django.forms import fields
 try:


### PR DESCRIPTION
if optional simplejson is not available, import the default json module, else use django.utils.simplejson as fallback

the common consensus is that simplejson is faster than the built-in json module due to the optional c extensions that may be present, correct?

please also merge this into the postgresql branch too
