### PR TITLE
fix jsonfield in the base class can not decode correctly bug

### DIFF
--- a/jsonfield/fields.py
+++ b/jsonfield/fields.py
@@ -84,6 +84,11 @@ class JSONFieldBase(six.with_metaclass(SubfieldBase, models.Field)):
     def to_python(self, value):
         """The SubfieldBase metaclass calls pre_init instead of to_python, however to_python
         is still necessary for Django's deserializer"""
+        if isinstance(value, six.string_types):
+            try:
+                return json.loads(value, **self.load_kwargs)
+            except ValueError:
+                raise ValidationError(_("Enter valid JSON"))
         return value
 
     def get_db_prep_value(self, value, connection, prepared=False):

--- a/jsonfield/subclassing.py
+++ b/jsonfield/subclassing.py
@@ -31,7 +31,7 @@ class Creator(object):
     def __get__(self, obj, type=None):
         if obj is None:
             raise AttributeError('Can only be accessed via an instance.')
-        return obj.__dict__[self.field.name]
+        return self.field.to_python(obj.__dict__[self.field.name])
 
     def __set__(self, obj, value):
         # Usually this would call to_python, but we've changed it to pre_init


### PR DESCRIPTION
In [Issue 106](https://github.com/bradjasper/django-jsonfield/issues/106), I give a case that json field in the base class, but it can't be decoded when derive class get it instead of string(or Unicode).

I read your source code(be honest, I learn django in one month, many code I still can't understand) and clone it, I try to modify some functions to test their function. I found if I can use django raw to_python function it try to decode string or do something(In a word, **I want to decode any string if I can**). So I modify code here. :)

Btw, I found there is a tests.py file here, but I don't know how to run it to test my new version jsonfield. So I just create some class like Issue 106, do some `save()` and getting fields, it work correctly! At least I can use this code in my project.
