### PR TITLE
Set python_requires='>=3.6'

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 -------
 
+Unreleased
+^^^^^^^^^^
+
+- Add setuptoools ``python_requires`` check
+
 v3.0.0 02/14/2020
 ^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Framework :: Django',
     ],
+    python_requires='>=3.6',
 )


### PR DESCRIPTION
Will prevent users with Python 2.7 or 3.5 from downloading a sdist version they cannot build.

Note: supporting `python_requires` requires setuptools>=24.2.0 and pip>=9.0.0 to benefit from it.
Details here: https://packaging.python.org/guides/distributing-packages-using-setuptools/#python-requires