### PR TITLE
Remove help text from form field

### DIFF
--- a/src/jsonfield/forms.py
+++ b/src/jsonfield/forms.py
@@ -19,7 +19,6 @@ class JSONField(fields.CharField):
         self.dump_kwargs = dump_kwargs if dump_kwargs else {}
         self.load_kwargs = load_kwargs if load_kwargs else {}
 
-        kwargs.setdefault('help_text', _("Enter valid JSON."))
         super().__init__(*args, **kwargs)
 
     def to_python(self, value):


### PR DESCRIPTION
The current implementation where the form field sets the default help text does not work, as the model field's `formfield()` will always provide its own default value, even if an empty string.

There isn't really a good solution here, so I think the best option is to just remove the `help_text`, as no builtin Django fields provide their own `help_text` (i.e., `help_text` should always be supplied by the user, not the field). 

Fixes #95.