### PR TITLE
Handle loading invalid JSON from db

### DIFF
--- a/tests/test_jsonfield.py
+++ b/tests/test_jsonfield.py
@@ -1,3 +1,4 @@
+import warnings
 from collections import OrderedDict
 from decimal import Decimal
 
@@ -304,6 +305,26 @@ class MiscTests(TestCase):
         child = MTIChildModel.objects.get()
         self.assertEqual(child.parent_data, {'parent': 'data'})
         self.assertEqual(child.child_data, {'child': 'data'})
+
+    def test_load_invalid_json(self):
+        # Ensure invalid DB values don't crash deserialization
+        from django.db import connection
+
+        with connection.cursor() as cursor:
+            cursor.execute('INSERT INTO tests_jsonnotrequiredmodel (json) VALUES ("foo")')
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            instance = JSONNotRequiredModel.objects.get()
+
+        self.assertEqual(len(w), 1)
+        self.assertIs(w[0].category, RuntimeWarning)
+        self.assertEqual(str(w[0].message), (
+            'tests.JSONNotRequiredModel.json failed to load invalid json (foo) '
+            'from the database. The value has been returned as a string instead.'
+        ))
+
+        self.assertEqual(instance.json, 'foo')
 
 
 class QueryTests(TestCase):


### PR DESCRIPTION
This handles loading invalid JSON values (such as an empty string) from the database. While the field should never save any invalid JSON, it's possible that an invalid value was loaded into the DB through other means. A `RuntimeWarning` is issued, however the value is still loaded as a string.

Fixes #199 and fixes #100.