### PR TITLE
Don't autofill fields with null

### DIFF
--- a/src/jsonfield/forms.py
+++ b/src/jsonfield/forms.py
@@ -59,6 +59,6 @@ class JSONField(fields.CharField):
             return InvalidJSONInput(data)
 
     def prepare_value(self, value):
-        if isinstance(value, InvalidJSONInput):
+        if isinstance(value, InvalidJSONInput) or value is None:
             return value
         return json.dumps(value, **self.dump_kwargs)


### PR DESCRIPTION
After 92613991d76429c65bd35aebea3470c0baf26520, a blank field is automatically populated with null. This is bad for `null=True` fields, since those should be left empty when unpopulated. This PR preserves the behaviour from before.